### PR TITLE
DEV-1600:

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -14,6 +14,7 @@ class Comment extends Eloquent
 {
     protected $table = 'comments';
     protected $primaryKey = 'comment_ID';
+    public $timestamps = false;
 
     /**
      * Post relationship


### PR DESCRIPTION
- Adds $timestamps = false;
- otherwise it try's to set timestamps on fields 'updates_at' and 'created_at'. These fields don't exists.

Signed-off-by: Daniel Ravenshorst <daniel.ravenshorst@dealerdirect.nl>